### PR TITLE
Add libqt5gui5-gles to stage-packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,18 +21,19 @@ parts:
             - qtbase5-dev
             - qtdeclarative5-ubuntu-ui-toolkit-plugin
             - qtdeclarative5-dev
+            - libqt5gui5-gles
         filesets:
             unwanted:
                 - -usr/lib/x86_64-linux-gnu/libQt5*.so* 
                 - -usr/lib/x86_64-linux-gnu/qt5/
                 - -usr/lib/x86_64-linux-gnu/libOxideQt*
                 - -usr/lib/x86_64-linux-gnu/oxide-qt/
-        stage: 
-            - $unwanted
-    prebuilt:
-        plugin: tar-content
-        source: https://github.com/penk/oxide-eglfs-snap/releases/download/beta/prebuilt-qt5-amd64.tgz
-        destination: ./usr/lib/x86_64-linux-gnu/
+#        stage: 
+#            - $unwanted
+#    prebuilt:
+#        plugin: tar-content
+#        source: https://github.com/penk/oxide-eglfs-snap/releases/download/beta/prebuilt-qt5-amd64.tgz
+#        destination: ./usr/lib/x86_64-linux-gnu/
     common:
         plugin: dump
         source: data


### PR DESCRIPTION
Updated to stage libqt5gui5-gles instead of using the prebuilt qt5 libraries. Commented out stage step to remove $unwanted and commented out prebuilt section.